### PR TITLE
Update `submitPatch` to handle verification fee

### DIFF
--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -95,6 +95,8 @@ contract Issuehunter {
         // exception.
         require(campaigns[issueId].createdBy == 0);
 
+        // TODO: verify that `verifier` is a valid address
+
         campaigns[issueId] = Campaign({
             rewarded: false,
             total: 0,

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -293,14 +293,14 @@ contract Issuehunter {
     ////////////////////////////////////////////////////////////////////////////
     // Getters
     ////////////////////////////////////////////////////////////////////////////
-    function campaignFunds(bytes32 issueId, address funder) public view returns (uint amount) {
+    function campaignFunds(bytes32 issueId, address funder) public returns (uint amount) {
         // Require that a campaign exists
         require(campaigns[issueId].createdBy != 0);
 
         return campaigns[issueId].funds[funder];
     }
 
-    function campaignResolutions(bytes32 issueId, address author) public view returns (bytes32 ref) {
+    function campaignResolutions(bytes32 issueId, address author) public returns (bytes32 ref) {
         // Require that a campaign exists
         require(campaigns[issueId].createdBy != 0);
 

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -16,6 +16,10 @@ contract Issuehunter {
     // verified patch's author can't withdraw campaign's reward anymore.
     uint public rewardPeriod;
 
+    // Estimated gas to execute `verifyPatch`. This value will be used to
+    // calculate the patch verifier fee that should applied to submit patches.
+    uint public constant verifyPatchEstimatedGas = 65511;
+
     // A crowdfunding campaign.
     struct Campaign {
         // A flag that is true if a verified patch author's has been rewarded.
@@ -129,15 +133,23 @@ contract Issuehunter {
 
     // Submit a new patch.
     //
-    // TODO: the sender must pay a fee that will be used by the patch verifier
-    // to send the transaction to verify the patch.
-    function submitPatch(bytes32 issueId, bytes32 ref) public {
+    // This method is defined as payable because the sender must pay a patch
+    // verification fee that will be used by the patch verifier, after the patch
+    // has been verified, to inform the contract of the successful verification.
+    function submitPatch(bytes32 issueId, bytes32 ref) public payable {
         // Require that a campaign exists
         require(campaigns[issueId].createdBy != 0);
         // Fail if sender already submitted the same patch
         require(campaigns[issueId].patches[msg.sender] == 0 || campaigns[issueId].patches[msg.sender] != ref);
 
         // TODO: require that a campaign hasn't any verified patch
+
+        // Calculate fee amount based on the current transaction's gas price
+        uint feeAmount = _patchVerificationFee(tx.gasprice);
+        // Fail if the transaction value is less than the verification fee
+        require(msg.value >= feeAmount);
+        // Pay the patch verification fee
+        campaigns[issueId].patchVerifier.transfer(msg.value);
 
         campaigns[issueId].patches[msg.sender] = ref;
 
@@ -288,6 +300,14 @@ contract Issuehunter {
         funder.transfer(amount);
 
         return amount;
+    }
+
+    // The patch verification fee amount is set to twice the amount of Ether
+    // needed to send a transaction to execute the method `verifyPatch`
+    // according the gas price in input. In theory this should be more than
+    // enough for the verifier to run the transaction and to spare some gas.
+    function _patchVerificationFee(uint gasprice) internal returns (uint) {
+        return gasprice * verifyPatchEstimatedGas * 2;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/test/issuehunter.js
+++ b/test/issuehunter.js
@@ -694,7 +694,7 @@ contract('Issuehunter', function (accounts) {
   })
 
   describe('withdrawReward', function () {
-    it('should withdraw the whole campaing\'s amount as a reward', function () {
+    it('should withdraw the whole campaign\'s amount as a reward', function () {
       const issueId = 'new-campaign-15'
       const ref = 'sha'
       const funder1 = accounts[1]
@@ -843,7 +843,7 @@ contract('Issuehunter', function (accounts) {
       const txValue = 10
       const author = accounts[1]
 
-      it('successfully withdraws the whole campaing\'s amount as a reward', function () {
+      it('successfully withdraws the whole campaign\'s amount as a reward', function () {
         return newCampaign(issueId, accounts[1]).then(function () {
           return fundCampaign(issueId, txValue, funder)
         }).then(function () {
@@ -918,7 +918,7 @@ contract('Issuehunter', function (accounts) {
   })
 
   describe('withdrawSpareFunds', function () {
-    it('should withdraw spare funds in the campaing', function () {
+    it('should withdraw spare funds in the campaign', function () {
       const issueId = 'new-campaign-21'
       const ref = 'sha'
       const funder1 = accounts[1]

--- a/test/issuehunter.js
+++ b/test/issuehunter.js
@@ -836,7 +836,7 @@ contract('Issuehunter', function (accounts) {
       })
     })
 
-    context('right before the execution period end', function () {
+    context('right before the reward period end', function () {
       const issueId = 'new-campaign-19'
       const ref = 'sha'
       const funder = accounts[1]
@@ -851,7 +851,7 @@ contract('Issuehunter', function (accounts) {
         }).then(function () {
           return verifyPatch(issueId, author, ref, patchVerifier)
         }).then(function () {
-          // The execution period end is one week after the pre-reward period
+          // The reward period end is one week after the pre-reward period
           // ends, that is 7 + 1 days from the moment the patch has been
           // verified
           return increaseTime(60 * 60 * 24 * 8)
@@ -873,7 +873,7 @@ contract('Issuehunter', function (accounts) {
 
     // TODO: I think this is not fair. The verified patch's author should always
     // be able to withdraw their reward.
-    context('past the execution period', function () {
+    context('past the reward period', function () {
       const issueId = 'new-campaign-20'
       const ref = 'sha'
       const funder = accounts[1]
@@ -938,9 +938,9 @@ contract('Issuehunter', function (accounts) {
       }).then(function () {
         return verifyPatch(issueId, author, ref, patchVerifier)
       }).then(function () {
-        // The execution period end is one week after the pre-reward period
+        // The reward period end is one week after the pre-reward period
         // ends, that is 7 + 1 days from the moment the patch has been verified
-        // Funders are allowed to withdraw spare funds right after the execution
+        // Funders are allowed to withdraw spare funds right after the reward
         // period is expired
         return increaseTime(60 * 60 * 24 * 8 + 1)
       }).then(function () {
@@ -1059,7 +1059,7 @@ contract('Issuehunter', function (accounts) {
       })
     })
 
-    context('right before the execution period expiration', function () {
+    context('right before the reward period expiration', function () {
       const issueId = 'new-campaign-25'
       const ref = 'sha'
       const funder = accounts[1]

--- a/test/issuehunter.js
+++ b/test/issuehunter.js
@@ -392,6 +392,21 @@ contract('Issuehunter', function (accounts) {
       })
     })
 
+    context('transaction fee is lower than required verification fee', function () {
+      const issueId = newCampaignId()
+      const ref = 'sha'
+
+      it('should fail to submit the same patch twice', function () {
+        const finalState = newCampaign(issueId, accounts[1]).then(function () {
+          return minVerificationFee
+        }).then(function (minFee) {
+          return submitPatchWithFee(issueId, ref, minFee.sub(1), accounts[1])
+        })
+
+        return assertContractException(finalState, 'An exception has been thrown')
+      })
+    })
+
     context('a campaign that doesn\'t exist', function () {
       const issueId = 'invalid'
       const ref = 'sha'

--- a/test/issuehunter.js
+++ b/test/issuehunter.js
@@ -334,21 +334,42 @@ contract('Issuehunter', function (accounts) {
       const issueId = 'new-campaign-4'
       const ref1 = 'sha-1'
       const ref2 = 'sha-2'
+      const verifier = accounts[0]
+
+      const verifierInitialBalance = addressBalance(verifier)
 
       return newCampaign(issueId, accounts[1]).then(function () {
         // Test a `submitPatch` transaction from account 2
         return submitPatch(issueId, ref1, accounts[1])
       }).then(function (ref) {
         assert.equal(web3.toUtf8(ref), ref1, 'Patch has been stored')
+        return Promise.all([minVerificationFee, verifierInitialBalance, addressBalance(verifier)])
+      }).then(function ([minFee, initialAmount, currentAmount]) {
+        // Note: compare account balance difference with a lower precision than
+        // wei. The result was ~ +/- 5000 wei, but I didn't investigate why.
+        // TODO: make this check stricter.
+        assert.equal(Math.round((currentAmount - initialAmount) / 100000) * 100000, minFee.toNumber(), 'Fee amount has been transferred to verifier\'s account')
         // Test a `submitPatch` transaction for the same commit SHA from a
         // different account
         return submitPatch(issueId, ref1, accounts[2])
       }).then(function (ref) {
         assert.equal(web3.toUtf8(ref), ref1, 'Patch has been stored')
+        return Promise.all([minVerificationFee, verifierInitialBalance, addressBalance(verifier)])
+      }).then(function ([minFee, initialAmount, currentAmount]) {
+        // Note: compare account balance difference with a lower precision than
+        // wei. The result was ~ +/- 5000 wei, but I didn't investigate why.
+        // TODO: make this check stricter.
+        assert.equal(Math.round((currentAmount - initialAmount) / 100000) * 100000, minFee.toNumber() * 2, 'Fee amount has been transferred to verifier\'s account')
         // Test a `submitPatch` transaction for a new commit SHA from account 2
         return submitPatch(issueId, ref2, accounts[1])
       }).then(function (ref) {
         assert.equal(web3.toUtf8(ref), ref2, 'Patch has been stored')
+        return Promise.all([minVerificationFee, verifierInitialBalance, addressBalance(verifier)])
+      }).then(function ([minFee, initialAmount, currentAmount]) {
+        // Note: compare account balance difference with a lower precision than
+        // wei. The result was ~ +/- 5000 wei, but I didn't investigate why.
+        // TODO: make this check stricter.
+        assert.equal(Math.round((currentAmount - initialAmount) / 100000) * 100000, minFee.toNumber() * 3, 'Fee amount has been transferred to verifier\'s account')
       })
     })
 


### PR DESCRIPTION
The new `submitPatch` is a _payable_ method that accepts a
verification fee. The sender must pay a patch verification fee that
will be used by the patch verifier, after the patch has been
verified, to inform the contract of the successful verification.

The patch verification fee amount is set to twice the amount of Ether
needed to send a transaction to execute the method `verifyPatch`
according the gas price in input. In theory this should be more than
enough for the verifier to run the transaction and to spare some gas.

See #13.