### PR TITLE
Tips

### DIFF
--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -107,7 +107,7 @@ contract Issuehunter is Mortal {
     }
 
     /// Creates a new campaign.
-    function createCampaignExtended(bytes32 issueId, address verifier, uint _tipPerMille) public {
+    function createCampaignExtended(bytes32 issueId, address _patchVerifier, uint _tipPerMille) public {
         // If a campaign for the selected issue exists already throws an
         // exception.
         require(campaigns[issueId].createdBy == 0);
@@ -124,7 +124,7 @@ contract Issuehunter is Mortal {
             preRewardPeriodExpiresAt: 0,
             rewardPeriodExpiresAt: 0,
             resolvedBy: 0,
-            patchVerifier: verifier,
+            patchVerifier: _patchVerifier,
             tipPerMille: _tipPerMille
         });
 

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -79,8 +79,10 @@ contract Issuehunter is Mortal {
     function Issuehunter() public {
         defaultPatchVerifier = msg.sender;
         // The default pre-reward period is one day
+        // TODO: make this value a constant
         preRewardPeriod = 86400;
         // The default execution period is one week.
+        // TODO: make this value a constant
         rewardPeriod = 604800;
     }
 

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -335,23 +335,12 @@ contract Issuehunter is Mortal {
         WithdrawSpareFunds(issueId, msg.sender, amount);
     }
 
-    // The default patch verifier, that is the contract owner, has the ability
-    // to withdraw tips.
+    // The contract owner, has the ability to withdraw tips.
     //
-    // Tips are calculated after a patch has been successfully verified. From
-    // that moment on, tips are applied to all subsequent withdrawals from
-    // campaign's funds (fund rollbacks, reward withdrawal, spare funds
-    // withdrawals).
-    //
-    // TODO: it doesn't make a lot of sense that the default patch verifier is
-    // used instead of the owner of the contract. Let's add a new contract
-    // variable to store the contract's owner address.
-    function withdrawTips() public {
-        // msg.sender must be the contract's owner
-        //
-        // TODO: fix confusion between default patch verifier and contract's
-        // owner
-        require(msg.sender == defaultPatchVerifier);
+    // Tips are computed after a patch has been successfully verified. From that
+    // moment on, tips are applied to all subsequent campaign's funds
+    // withdrawals (fund rollbacks, reward withdrawal, spare funds withdrawals).
+    function withdrawTips() onlyOwner public {
         // Disallow `withdrawTips` if `tipsAmount` is zero
         require(tipsAmount > 0);
 

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -22,9 +22,7 @@ contract Issuehunter is Mortal {
 
     // Estimated gas to execute `verifyPatch`. This value will be used to
     // calculate the patch verifier fee that should applied to submit patches.
-    //
-    // TODO: recalculate after fee application (!!!)
-    uint public constant verifyPatchEstimatedGas = 65511;
+    uint public constant verifyPatchEstimatedGas = 107255;
 
     // Default tip per mille.
     uint public constant defaultTipPerMille = 50;

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -36,6 +36,7 @@ contract Issuehunter is Mortal {
         bool rewarded;
 
         // The total amount of funds associated to the issue.
+        // TODO: rename to "rewardAmount"?
         uint total;
 
         // The address that created the campaign. Mainly used to check if a
@@ -166,6 +167,10 @@ contract Issuehunter is Mortal {
 
         // TODO: require that a campaign hasn't any verified patch
 
+        // TODO: require that a campaign has a positive reward amount (?) It
+        // doesn't make a lot of sense to submit a patch for a campaign that
+        // wouldn't give any reward, but maybe it's better to check anyway
+
         // Calculate fee amount based on the current transaction's gas price
         uint feeAmount = _patchVerificationFee(tx.gasprice);
         // Fail if the transaction value is less than the verification fee
@@ -262,6 +267,7 @@ contract Issuehunter is Mortal {
         // withdraw a reward even after the `rewardPeriodExpiresAt` has passed?
         require(now <= campaigns[issueId].rewardPeriodExpiresAt);
 
+        // Set campaign status as "rewarded"
         campaigns[issueId].rewarded = true;
         msg.sender.transfer(campaigns[issueId].total);
         WithdrawFunds(issueId, msg.sender);

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -84,7 +84,7 @@ contract Issuehunter is Mortal {
     event PatchSubmitted(bytes32 indexed issueId, address resolvedBy, bytes32 ref);
     event PatchVerified(bytes32 indexed issueId, address resolvedBy, bytes32 ref);
     event RollbackFunds(bytes32 indexed issueId, address funder, uint amount);
-    event WithdrawFunds(bytes32 indexed issueId, address resolvedBy);
+    event WithdrawReward(bytes32 indexed issueId, address resolvedBy, uint amount);
     event WithdrawSpareFunds(bytes32 indexed issueId, address funder, uint amount);
 
     /// Create a new contract instance and set message sender as the default
@@ -270,7 +270,8 @@ contract Issuehunter is Mortal {
         // Set campaign status as "rewarded"
         campaigns[issueId].rewarded = true;
         msg.sender.transfer(campaigns[issueId].total);
-        WithdrawFunds(issueId, msg.sender);
+
+        WithdrawReward(issueId, msg.sender, campaigns[issueId].total);
 
         // TODO: archive campaign (?)
         //

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -22,16 +22,16 @@ contract Issuehunter is Mortal {
 
     // Estimated gas to execute `verifyPatch`. This value will be used to
     // calculate the patch verifier fee that should applied to submit patches.
-    uint public constant verifyPatchEstimatedGas = 107255;
+    uint public constant VERIFY_PATCH_ESTIMATED_GAS = 107255;
 
     // Default tip per mille.
-    uint public constant defaultTipPerMille = 50;
+    uint public constant DEFAULT_TIP_PER_MILLE = 50;
 
     // 1% is the minimum tip.
-    uint public constant minTipPerMille = 10;
+    uint public constant MIN_TIP_PER_MILLE = 10;
 
     // 20% is the maximum tip.
-    uint public constant maxTipPerMille = 200;
+    uint public constant MAX_TIP_PER_MILLE = 200;
 
     // A crowdfunding campaign.
     struct Campaign {
@@ -109,10 +109,10 @@ contract Issuehunter is Mortal {
     }
 
     /// Creates a new campaign with `defaultPatchVerifier` as the allowed
-    //  address to verify patches, and the `defaultTipPerMille` as the per mille
-    //  funds tip value.
+    //  address to verify patches, and the `DEFAULT_TIP_PER_MILLE` as the per
+    //  mille funds tip value.
     function createCampaign(bytes32 issueId) public {
-        createCampaignExtended(issueId, defaultPatchVerifier, defaultTipPerMille);
+        createCampaignExtended(issueId, defaultPatchVerifier, DEFAULT_TIP_PER_MILLE);
     }
 
     /// Creates a new campaign.
@@ -120,9 +120,9 @@ contract Issuehunter is Mortal {
         // If a campaign for the selected issue exists already throws an
         // exception.
         require(campaigns[issueId].createdBy == 0);
-        // Requires that tip is valid, that is between `minTipPerMille` and
-        // `maxTipPerMille`
-        require(_tipPerMille >= minTipPerMille && _tipPerMille <= maxTipPerMille);
+        // Requires that tip is valid, that is between `MIN_TIP_PER_MILLE` and
+        // `MAX_TIP_PER_MILLE`
+        require(_tipPerMille >= MIN_TIP_PER_MILLE && _tipPerMille <= MAX_TIP_PER_MILLE);
 
         // TODO: verify that `verifier` is a valid address
 
@@ -382,7 +382,7 @@ contract Issuehunter is Mortal {
     // according the gas price in input. In theory this should be more than
     // enough for the verifier to run the transaction and to spare some gas.
     function _patchVerificationFee(uint gasprice) internal returns (uint) {
-        return gasprice * verifyPatchEstimatedGas * 2;
+        return gasprice * VERIFY_PATCH_ESTIMATED_GAS * 2;
     }
 
     // Return the reciprocal of the `tipPerMille` value applied to `amount`.

--- a/contracts/Issuehunter.sol
+++ b/contracts/Issuehunter.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.11;
 
 import "./Mortal.sol";
 
+
 // TODO: contract description
 contract Issuehunter is Mortal {
 

--- a/contracts/Mortal.sol
+++ b/contracts/Mortal.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.11;
 
 import "./Owned.sol";
 
+
 contract Mortal is Owned {
     /* Function to recover the funds on the contract */
     function kill() onlyOwner { selfdestruct(owner); }

--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.11;
 
+
 contract Owned {
     address owner;
 

--- a/test/issuehunter.js
+++ b/test/issuehunter.js
@@ -179,7 +179,7 @@ contract('Issuehunter', function (accounts) {
     return issuehunter.then(function (instance) {
       return instance.withdrawReward(issueId, { from: account })
     }).then(function (result) {
-      assert(findEvent(result, 'WithdrawFunds'), 'A new `WithdrawFunds` event has been triggered')
+      assert(findEvent(result, 'WithdrawReward'), 'A new `WithdrawReward` event has been triggered')
       return issuehunter
     }).then(function (instance) {
       return instance.campaigns.call(issueId)

--- a/test/issuehunter.js
+++ b/test/issuehunter.js
@@ -892,7 +892,7 @@ contract('Issuehunter', function (accounts) {
         assert.equal(amount.toNumber(), txValue2, 'Campaign\'s funder amount is unmodified')
         return Promise.all([initialAuthorBalance, addressBalance(author), DEFAULT_TIP_PER_MILLE])
       }).then(function ([initialAmount, currentAmount, tipPerMille]) {
-        withdrawableAmount = Math.floor((txValue1 + txValue2) * (1000 - tipPerMille.toNumber()) / 1000)
+        const withdrawableAmount = Math.floor((txValue1 + txValue2) * (1000 - tipPerMille.toNumber()) / 1000)
         // TODO: find a better way to check for a user's account balance delta
         // This is a workaround and it won't work under all conditions. It
         // partially works because transactions are in wei, but gas are some
@@ -1122,8 +1122,8 @@ contract('Issuehunter', function (accounts) {
         assert.equal(amount.toNumber(), txValue2, 'Campaign\'s funder amount is unmodified')
         return Promise.all([funder1InitialBalance, addressBalance(funder1), DEFAULT_TIP_PER_MILLE])
       }).then(function ([initialAmount, currentAmount, tipPerMille]) {
-        withdrawableAmount = Math.floor(txValue1 * (1000 - tipPerMille.toNumber()) / 1000)
-        expectedBalanceDelta = withdrawableAmount - txValue1
+        const withdrawableAmount = Math.floor(txValue1 * (1000 - tipPerMille.toNumber()) / 1000)
+        const expectedBalanceDelta = withdrawableAmount - txValue1
         // TODO: find a better way to check for a user's account balance delta
         // This is a workaround and it won't work under all conditions. It
         // partially works because transactions are in wei, but gas are some

--- a/test/issuehunter.js
+++ b/test/issuehunter.js
@@ -83,11 +83,11 @@ contract('Issuehunter', function (accounts) {
   const patchVerifier = accounts[0]
   const issuehunter = Issuehunter.deployed()
 
-  const verifyPatchEstimatedGas = issuehunter.then(function (instance) {
-    return instance.verifyPatchEstimatedGas.call()
+  const VERIFY_PATCH_ESTIMATED_GAS = issuehunter.then(function (instance) {
+    return instance.VERIFY_PATCH_ESTIMATED_GAS.call()
   })
 
-  const minVerificationFee = Promise.all([gasPrice(), verifyPatchEstimatedGas]).then(function ([gprice, estGas]) {
+  const minVerificationFee = Promise.all([gasPrice(), VERIFY_PATCH_ESTIMATED_GAS]).then(function ([gprice, estGas]) {
     return gprice.mul(estGas).mul(2)
   })
 
@@ -95,16 +95,16 @@ contract('Issuehunter', function (accounts) {
     return instance.defaultPatchVerifier.call()
   })
 
-  const defaultTipPerMille = issuehunter.then(function (instance) {
-    return instance.defaultTipPerMille.call()
+  const DEFAULT_TIP_PER_MILLE = issuehunter.then(function (instance) {
+    return instance.DEFAULT_TIP_PER_MILLE.call()
   })
 
-  const minTipPerMille = issuehunter.then(function (instance) {
-    return instance.minTipPerMille.call()
+  const MIN_TIP_PER_MILLE = issuehunter.then(function (instance) {
+    return instance.MIN_TIP_PER_MILLE.call()
   })
 
-  const maxTipPerMille = issuehunter.then(function (instance) {
-    return instance.maxTipPerMille.call()
+  const MAX_TIP_PER_MILLE = issuehunter.then(function (instance) {
+    return instance.MAX_TIP_PER_MILLE.call()
   })
 
   const newCampaign = function (issueId, account) {
@@ -249,7 +249,7 @@ contract('Issuehunter', function (accounts) {
       return Promise.all([
         newCampaign(issueId, accounts[1]),
         defaultPatchVerifier,
-        defaultTipPerMille
+        DEFAULT_TIP_PER_MILLE
       ]).then(function ([campaign, defPatchVerifier, defTipPerMille]) {
         assert.ok(!campaign[0], 'A new campaign that has not been rewarded should be present')
         assert.equal(campaign[1].toNumber(), 0, 'A new campaign with a zero total amount should be present')
@@ -283,7 +283,7 @@ contract('Issuehunter', function (accounts) {
       const issueId = newCampaignId()
       const patchVerifier = accounts[3]
 
-      return defaultTipPerMille.then(function (tipPerMille) {
+      return DEFAULT_TIP_PER_MILLE.then(function (tipPerMille) {
         return newCampaignExtended(issueId, patchVerifier, tipPerMille, accounts[1])
       }).then(function (campaign) {
         assert.ok(!campaign[0], 'A new campaign that has not been rewarded should be present')
@@ -300,7 +300,7 @@ contract('Issuehunter', function (accounts) {
       it('should create a new crowdfunding campaign with a custom tip value', function () {
         const issueId = newCampaignId()
         const patchVerifier = accounts[3]
-        const randomTipPerMille = Promise.all([minTipPerMille, maxTipPerMille]).then(function ([min, max]) {
+        const randomTipPerMille = Promise.all([MIN_TIP_PER_MILLE, MAX_TIP_PER_MILLE]).then(function ([min, max]) {
           // Return a random integer between min inclusive and max inclusive
           // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
           return Math.floor(Math.random() * (max.toNumber() + 1 - min.toNumber())) + min.toNumber()
@@ -316,28 +316,28 @@ contract('Issuehunter', function (accounts) {
         })
       })
 
-      it('should allow a custom tip value that is equal to minTipPerMille', function () {
+      it('should allow a custom tip value that is equal to MIN_TIP_PER_MILLE', function () {
         const issueId = newCampaignId()
         const patchVerifier = accounts[3]
 
-        return minTipPerMille.then(function (minTip) {
+        return MIN_TIP_PER_MILLE.then(function (minTip) {
           return Promise.all([
             newCampaignExtended(issueId, patchVerifier, minTip, accounts[1]),
-            minTipPerMille
+            MIN_TIP_PER_MILLE
           ])
         }).then(function ([campaign, minTip]) {
           assert.equal(campaign[7].toNumber(), minTip, 'The custom tip per mille should be the new campaign\'s tip value')
         })
       })
 
-      it('should allow a custom tip value that is equal to maxTipPerMille', function () {
+      it('should allow a custom tip value that is equal to MAX_TIP_PER_MILLE', function () {
         const issueId = newCampaignId()
         const patchVerifier = accounts[3]
 
-        return maxTipPerMille.then(function (maxTip) {
+        return MAX_TIP_PER_MILLE.then(function (maxTip) {
           return Promise.all([
             newCampaignExtended(issueId, patchVerifier, maxTip, accounts[1]),
-            maxTipPerMille
+            MAX_TIP_PER_MILLE
           ])
         }).then(function ([campaign, maxTip]) {
           assert.equal(campaign[7].toNumber(), maxTip, 'The custom tip per mille should be the new campaign\'s tip value')
@@ -349,7 +349,7 @@ contract('Issuehunter', function (accounts) {
         const patchVerifier = accounts[3]
 
         it('should fail to create a new campaign', function () {
-          const finalState = minTipPerMille.then(function (minTip) {
+          const finalState = MIN_TIP_PER_MILLE.then(function (minTip) {
             return newCampaignExtended(issueId, patchVerifier, minTip.toNumber() - 1, accounts[1])
           })
 
@@ -362,7 +362,7 @@ contract('Issuehunter', function (accounts) {
         const patchVerifier = accounts[3]
 
         it('should fail to create a new campaign', function () {
-          const finalState = maxTipPerMille.then(function (maxTip) {
+          const finalState = MAX_TIP_PER_MILLE.then(function (maxTip) {
             return newCampaignExtended(issueId, patchVerifier, maxTip.toNumber() + 1, accounts[1])
           })
 
@@ -376,10 +376,10 @@ contract('Issuehunter', function (accounts) {
       const patchVerifier = accounts[3]
 
       it('should fail to create a new campaign', function () {
-        const finalState = defaultTipPerMille.then(function (tipPerMille) {
+        const finalState = DEFAULT_TIP_PER_MILLE.then(function (tipPerMille) {
           return newCampaignExtended(issueId, patchVerifier, tipPerMille, accounts[1])
         }).then(function () {
-          return Promise.all([issuehunter, defaultTipPerMille])
+          return Promise.all([issuehunter, DEFAULT_TIP_PER_MILLE])
         }).then(function ([instance, tipPerMille]) {
           return instance.createCampaignExtended(issueId, patchVerifier, tipPerMille, { from: accounts[1] })
         })
@@ -559,7 +559,7 @@ contract('Issuehunter', function (accounts) {
       const ref = 'sha'
       const author = accounts[1]
 
-      const expectedTipsAmount = defaultTipPerMille.then(function (tipPerMille) {
+      const expectedTipsAmount = DEFAULT_TIP_PER_MILLE.then(function (tipPerMille) {
         return txValue - (txValue * (1000 - tipPerMille.toNumber()) / 1000)
       })
 
@@ -890,7 +890,7 @@ contract('Issuehunter', function (accounts) {
         return instance.campaignFunds.call(issueId, funder2)
       }).then(function (amount) {
         assert.equal(amount.toNumber(), txValue2, 'Campaign\'s funder amount is unmodified')
-        return Promise.all([initialAuthorBalance, addressBalance(author), defaultTipPerMille])
+        return Promise.all([initialAuthorBalance, addressBalance(author), DEFAULT_TIP_PER_MILLE])
       }).then(function ([initialAmount, currentAmount, tipPerMille]) {
         withdrawableAmount = Math.floor((txValue1 + txValue2) * (1000 - tipPerMille.toNumber()) / 1000)
         // TODO: find a better way to check for a user's account balance delta
@@ -1120,7 +1120,7 @@ contract('Issuehunter', function (accounts) {
         return instance.campaignFunds.call(issueId, funder2)
       }).then(function (amount) {
         assert.equal(amount.toNumber(), txValue2, 'Campaign\'s funder amount is unmodified')
-        return Promise.all([funder1InitialBalance, addressBalance(funder1), defaultTipPerMille])
+        return Promise.all([funder1InitialBalance, addressBalance(funder1), DEFAULT_TIP_PER_MILLE])
       }).then(function ([initialAmount, currentAmount, tipPerMille]) {
         withdrawableAmount = Math.floor(txValue1 * (1000 - tipPerMille.toNumber()) / 1000)
         expectedBalanceDelta = withdrawableAmount - txValue1
@@ -1305,7 +1305,7 @@ contract('Issuehunter', function (accounts) {
       const author = accounts[2]
       const owner = accounts[0]
 
-      const expectedTipsAmount = defaultTipPerMille.then(function (tipPerMille) {
+      const expectedTipsAmount = DEFAULT_TIP_PER_MILLE.then(function (tipPerMille) {
         return txValue - (txValue * (1000 - tipPerMille.toNumber()) / 1000)
       })
 


### PR DESCRIPTION
Tips are "applied" when a patch is verified. The tips amount is stored
in a new `tipsAmount` campaign's attribute and it's added to the
`tipsAmount` contract's attribute.

Campaign's attribute is used to keep historical track of campaigns
tips.

Contract's attribute is used to implement `withdrawTips`, a method
that can be used by the contract's owner to withdraw tips. After each
tips withdrawal the attribute is reset to zero.

Funders and the verified patch author will be able to withdraw their
Ether minus the application of the campaign's tip per mille, stored
in a campaign's `tipsPerMille` attribute.

See https://github.com/issuehunter/issuehunter/issues/12.

#### Withdrawing tips

The function `withdrawTips` can be used only by the contract's owner
to withdraw the current tips amount from the contract if it's a value
greater than zero.

#### A note about tips per mille computation

Withdrawable amounts are calculated as reciprocal of a `tipsPerMille`
value. All amounts are `uint` and in Solidity integer division
truncates the result. For this reason the total amount of
withdrawable, that is the sum of reciprocals, should always be less
than the reciprocal of the total campaign amount. This means that the
sum of withdrawable amounts + the campaign's `tipsAmount` is less
than or equal to the total withdrawable amount + the campaign's
`tipsAmount`.

##### Example

```
funds[backerA] = 10
funds[backerB] = 10
funds[backerC] = 10
tipsPerMille = 50

totalAmount = funds.sum = 10 + 10 + 10 = 30
withdrawableReward
  = totalAmount * (1000 - tipsPerMille) / 1000
  = 30 * (1000 - 50) / 1000
  = 28.5
  = 28 (int)
tipsAmount
  = totalAmount - withdrawableReward
  = 30 - 28
  = 2

withdrawableAmounts[backerA]
  = funds[backerA] * (1000 - tipsPerMille) / 1000
  = 10 * (1000 - 50) / 1000
  = 9.5
  = 9 (int)
withdrawableAmounts[backerB]
  = funds[backerB] * (1000 - tipsPerMille) / 1000
  = 10 * (1000 - 50) / 1000
  = 9.5
  = 9 (int)
withdrawableAmounts[backerC]
  = funds[backerC] * (1000 - tipsPerMille) / 1000
  = 10 * (1000 - 50) / 1000
  = 9.5
  = 9 (int)
```

In this example if all funders rollback their funds after the patch
has been verified, they will be able to withdraw 27, that is less than
or equal to the total withdrawable amount, that is 28, but the
contract owner will be able to withdraw only 2 and the contract will
hold a spare amount of 1.

#### TODO

- [x] Add a PR description
- [x] Add missing tests
- [x] Add a function to withdraw tips
- [x] Update `verifyPatch` estimated gas
- [x] Use the `onlyOwner` modifier, that's been added by https://github.com/issuehunter/issuehunter/pull/7, in `withdrawTips`